### PR TITLE
Make required numpy version less strict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     version="0.0.1",
     packages=['numpy-stubs'],
     # PEP 561 requires these
-    install_requires=['numpy~=1.14.0'],
+    install_requires=['numpy>=1.14.0'],
     package_data=find_stubs('numpy-stubs'),
 )


### PR DESCRIPTION
Right now, this repository depends on a rather outdated version of numpy,  Thus, if I want to use these stubs in a project, I have to use an old version of numpy, which doesn't seem ideal.  I just changed the numpy requirement to be more permissive; I would imagine that numpy's api hasn't changed in such a way to make these stubs invalid since numpy 1.14. Ideally, this would be updated in sync with numpy's release cycle to keep the dependencies in sync, but it doesn't seem like there's been much activity on this repository for a while.  I really just want to be able to type `pip install git+https://github.com/numpy/numpy-stubs` and have something that works without having to downgrade numpy -- this pull request should do that :)