### PR TITLE
Added hint for ndarray.__new__

### DIFF
--- a/numpy-stubs/__init__.pyi
+++ b/numpy-stubs/__init__.pyi
@@ -278,9 +278,20 @@ class _ArrayOrScalarCommon(
     # TODO(shoyer): remove when all methods are defined
     def __getattr__(self, name) -> Any: ...
 
+_BufferType = Union[ndarray, bytes, bytearray, memoryview]
+
 class ndarray(_ArrayOrScalarCommon, Iterable, Sized, Container):
     real: ndarray
     imag: ndarray
+    def __new__(
+        cls,
+        shape: Sequence[int],
+        dtype: Union[_DtypeLike, str] = ...,
+        buffer: _BufferType = ...,
+        offset: int = ...,
+        strides: _ShapeLike = ...,
+        order: Optional[str] = ...,
+    ) -> ndarray: ...
     @property
     def dtype(self) -> _Dtype: ...
     @dtype.setter


### PR DESCRIPTION
`numpy.ndarray.__new__` previously did not have any type definitions, meaning that code that directly instantiates `np.ndarray` instances would be flagged by mypy as having unexpected arguments.

I think this should fix the issue - at the very least this change removes what I consider to be invalid warnings on my codebase - although I'm unsure about whether the type for the buffer is correct. 