### PR TITLE
Array Creation Routines: zeros and ones

### DIFF
--- a/numpy-stubs/__init__.pyi
+++ b/numpy-stubs/__init__.pyi
@@ -479,17 +479,11 @@ def array(
     subok: bool = ...,
     ndmin: int = ...,
 ) -> ndarray: ...
-
 def zeros(
-    shape: _ShapeLike,
-    dtype: _DtypeLike = ...,
-    order: Optional[str] = ...,
+    shape: _ShapeLike, dtype: _DtypeLike = ..., order: Optional[str] = ...
 ) -> ndarray: ...
-
 def ones(
-    shape: _ShapeLike,
-    dtype: _DtypeLike = ...,
-    order: Optional[str] = ...,
+    shape: _ShapeLike, dtype: _DtypeLike = ..., order: Optional[str] = ...
 ) -> ndarray: ...
 
 # TODO(shoyer): remove when the full numpy namespace is defined

--- a/numpy-stubs/__init__.pyi
+++ b/numpy-stubs/__init__.pyi
@@ -480,5 +480,17 @@ def array(
     ndmin: int = ...,
 ) -> ndarray: ...
 
+def zeros(
+    shape: _ShapeLike,
+    dtype: _DtypeLike = ...,
+    order: Optional[str] = ...,
+) -> ndarray: ...
+
+def ones(
+    shape: _ShapeLike,
+    dtype: _DtypeLike = ...,
+    order: Optional[str] = ...,
+) -> ndarray: ...
+
 # TODO(shoyer): remove when the full numpy namespace is defined
 def __getattr__(name: str) -> Any: ...

--- a/tests/fail/simple.py
+++ b/tests/fail/simple.py
@@ -1,0 +1,10 @@
+"""Simple expression that should fail with mypy."""
+
+import numpy as np
+
+# Array creation routines checks
+np.zeros("test")  # E: incompatible type
+np.zeros()  # E: Too few arguments
+
+np.ones("test")  # E: incompatible type
+np.ones()  # E: Too few arguments

--- a/tests/pass/simple.py
+++ b/tests/pass/simple.py
@@ -13,6 +13,10 @@ ndarray_func(np.array([1, 2]))
 array == 1
 array.dtype == float
 
+# Array creation routines checks
+ndarray_func(np.zeros([1, 2]))
+ndarray_func(np.ones([1, 2]))
+
 # Dtype construction
 np.dtype(float)
 np.dtype(np.float64)


### PR DESCRIPTION
I added a couple of commonly used array creation routines (ones and zeros).

One thing that I would imagine is out of scope of this PR and likely out of scope of this project is pythons treatment of `bool` as a subclass of `int`. This means with `_ShapeLike` we can have something like `np.zeros(False)` pass the analysis, while numpy at runtime raises a `TypeError`.