### PR TITLE
MAINT: broaden allowed lists in `_DtypeLike`

### DIFF
--- a/numpy-stubs/__init__.pyi
+++ b/numpy-stubs/__init__.pyi
@@ -56,12 +56,11 @@ _DtypeLike = Union[
     # (fixed_dtype, shape)
     Tuple[_DtypeLikeNested, _ShapeLike],
     # [(field_name, field_dtype, field_shape), ...]
-    List[
-        Union[
-            Tuple[Union[str, Tuple[str, str]], _DtypeLikeNested],
-            Tuple[Union[str, Tuple[str, str]], _DtypeLikeNested, _ShapeLike],
-        ]
-    ],
+    #
+    # The type here is quite broad because NumPy accepts quite a wide
+    # range of inputs inside the list; see the tests for some
+    # examples.
+    List[Any],
     # {'names': ..., 'formats': ..., 'offsets': ..., 'titles': ...,
     #  'itemsize': ...}
     # TODO: use TypedDict when/if it's officially supported

--- a/tests/pass/simple.py
+++ b/tests/pass/simple.py
@@ -25,9 +25,26 @@ np.dtype('float64')
 np.dtype(np.dtype(float))
 np.dtype(('U', 10))
 np.dtype((np.int32, (2, 2)))
-np.dtype([('R', 'u1'), ('G', 'u1'), ('B', 'u1')])
-np.dtype([('R', 'u1', 1)])
-np.dtype([('R', 'u1', (2, 2))])
+# Define the arguments on the previous line to prevent bidirectional
+# type inference in mypy from broadening the types.
+two_tuples_dtype = [('R', 'u1'), ('G', 'u1'), ('B', 'u1')]
+np.dtype(two_tuples_dtype)
+
+three_tuples_dtype = [('R', 'u1', 1)]
+np.dtype(three_tuples_dtype)
+
+mixed_tuples_dtype = [('R', 'u1'), ('G', np.unicode_, 1)]
+np.dtype(mixed_tuples_dtype)
+
+shape_tuple_dtype = [('R', 'u1', (2, 2))]
+np.dtype(shape_tuple_dtype)
+
+shape_like_dtype = [('R', 'u1', (2, 2)), ('G', np.unicode_, 1)]
+np.dtype(shape_like_dtype)
+
+object_dtype = [('field1', object)]
+np.dtype(object_dtype)
+
 np.dtype({'col1': ('U10', 0), 'col2': ('float32', 10)})
 np.dtype((np.int32, {'real': (np.int16, 0), 'imag': (np.int16, 2)}))
 np.dtype((np.int32, (np.int8, 4)))


### PR DESCRIPTION
Closes https://github.com/numpy/numpy-stubs/issues/42.

`np.dtype` accepts a wide variety of lists as dtypes, some examples
include:

- `[('R', 'u1'), ('G', np.unicode_, 1)]`
- `[('R', 'u1', (2, 2)), ('G', np.unicode_, 1)]`

Without further hints mypy is going to type those as `List[object]`,
so precise hints will require that users add annotations. In addition,
typing the above is challenging because the inputs have to be a list,
which is invariant, so you can't use `Union`s inside the list to
reduce the number of cases. Work around that by just accepting
`List[Any]`.