### PR TITLE
MAINT: set `zip_safe` to `False` in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,5 @@ setup(
     # PEP 561 requires these
     install_requires=['numpy>=1.14.0'],
     package_data=find_stubs('numpy-stubs'),
+    zip_safe=False,
 )


### PR DESCRIPTION
Closes https://github.com/numpy/numpy-stubs/issues/36.

See the mypy docs:

https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages

for more information.