### PR TITLE
ENH: add runtests option to find untyped module attributes

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+import argparse
+import ast
+import importlib
 import os
 import subprocess
 import sys
@@ -8,13 +11,84 @@ import pytest
 STUBS_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 
-def main():
+class FindAttributes(ast.NodeVisitor):
+    """Find top-level attributes/functions/classes in the stubs.
+
+    Do this by walking the stubs ast. See e.g.
+
+    https://greentreesnakes.readthedocs.io/en/latest/index.html
+
+    for more information on working with Python's ast.
+
+    """
+
+    def __init__(self):
+        self.attributes = set()
+
+    def visit_FunctionDef(self, node):
+        if node.name == '__getattr__':
+            # Not really a module member.
+            return
+        self.attributes.add(node.name)
+        # Do not call self.generic_visit; we are only interested in
+        # top-level functions.
+        return
+
+    def visit_ClassDef(self, node):
+        if not node.name.startswith('_'):
+            self.attributes.add(node.name)
+        return
+
+    def visit_AnnAssign(self, node):
+        self.attributes.add(node.target.id)
+
+
+def find_missing(module_name):
+    module_path = os.path.join(
+        STUBS_ROOT,
+        module_name.replace('numpy', 'numpy-stubs').replace('.', os.sep),
+        '__init__.pyi',
+    )
+
+    module = importlib.import_module(module_name)
+    module_attributes = {
+        attribute for attribute in dir(module)
+        if not attribute.startswith('_')
+    }
+
+    if os.path.isfile(module_path):
+        with open(module_path) as f:
+            tree = ast.parse(f.read())
+        ast_visitor = FindAttributes()
+        ast_visitor.visit(tree)
+        stubs_attributes = ast_visitor.attributes
+    else:
+        # No stubs for this module yet.
+        stubs_attributes = set()
+
+    missing = module_attributes - stubs_attributes
+    print('\n'.join(sorted(missing)))
+
+
+def run_pytest(argv):
     subprocess.run(
         [sys.executable, "-m", "pip", "install", STUBS_ROOT],
         capture_output=True,
         check=True,
     )
-    sys.exit(pytest.main([STUBS_ROOT] + sys.argv[1:]))
+    return pytest.main([STUBS_ROOT] + argv)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--find-missing')
+    args, remaining_argv = parser.parse_known_args()
+
+    if args.find_missing is not None:
+        find_missing(args.find_missing)
+        sys.exit(0)
+
+    sys.exit(run_pytest(remaining_argv))
 
 
 if __name__ == "__main__":

--- a/runtests.py
+++ b/runtests.py
@@ -13,35 +13,35 @@ STUBS_ROOT = os.path.dirname(os.path.abspath(__file__))
 # Technically "public" functions (they don't start with an underscore)
 # that we don't want to include.
 BLACKLIST = {
-    'numpy': {
+    "numpy": {
         # Stdlib modules in the namespace by accident
-        'absolute_import',
-        'warnings',
+        "absolute_import",
+        "warnings",
         # Accidentally public
-        'add_docstring',
-        'add_newdoc',
-        'add_newdoc_ufunc',
+        "add_docstring",
+        "add_newdoc",
+        "add_newdoc_ufunc",
         # Builtins
-        'bool',
-        'complex',
-        'float',
-        'int',
-        'long',
-        'object',
-        'str',
-        'unicode',
+        "bool",
+        "complex",
+        "float",
+        "int",
+        "long",
+        "object",
+        "str",
+        "unicode",
         # Should use numpy_financial instead
-        'fv',
-        'ipmt',
-        'irr',
-        'mirr',
-        'nper',
-        'npv',
-        'pmt',
-        'ppmt',
-        'pv',
-        'rate',
-    },
+        "fv",
+        "ipmt",
+        "irr",
+        "mirr",
+        "nper",
+        "npv",
+        "pmt",
+        "ppmt",
+        "pv",
+        "rate",
+    }
 }
 
 
@@ -60,7 +60,7 @@ class FindAttributes(ast.NodeVisitor):
         self.attributes = set()
 
     def visit_FunctionDef(self, node):
-        if node.name == '__getattr__':
+        if node.name == "__getattr__":
             # Not really a module member.
             return
         self.attributes.add(node.name)
@@ -69,7 +69,7 @@ class FindAttributes(ast.NodeVisitor):
         return
 
     def visit_ClassDef(self, node):
-        if not node.name.startswith('_'):
+        if not node.name.startswith("_"):
             self.attributes.add(node.name)
         return
 
@@ -80,14 +80,13 @@ class FindAttributes(ast.NodeVisitor):
 def find_missing(module_name):
     module_path = os.path.join(
         STUBS_ROOT,
-        module_name.replace('numpy', 'numpy-stubs').replace('.', os.sep),
-        '__init__.pyi',
+        module_name.replace("numpy", "numpy-stubs").replace(".", os.sep),
+        "__init__.pyi",
     )
 
     module = importlib.import_module(module_name)
     module_attributes = {
-        attribute for attribute in dir(module)
-        if not attribute.startswith('_')
+        attribute for attribute in dir(module) if not attribute.startswith("_")
     }
 
     if os.path.isfile(module_path):
@@ -103,7 +102,7 @@ def find_missing(module_name):
     blacklist = BLACKLIST.get(module_name, set())
 
     missing = module_attributes - stubs_attributes - blacklist
-    print('\n'.join(sorted(missing)))
+    print("\n".join(sorted(missing)))
 
 
 def run_pytest(argv):
@@ -117,7 +116,7 @@ def run_pytest(argv):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--find-missing')
+    parser.add_argument("--find-missing")
     args, remaining_argv = parser.parse_known_args()
 
     if args.find_missing is not None:

--- a/runtests.py
+++ b/runtests.py
@@ -10,6 +10,40 @@ import pytest
 
 STUBS_ROOT = os.path.dirname(os.path.abspath(__file__))
 
+# Technically "public" functions (they don't start with an underscore)
+# that we don't want to include.
+BLACKLIST = {
+    'numpy': {
+        # Stdlib modules in the namespace by accident
+        'absolute_import',
+        'warnings',
+        # Accidentally public
+        'add_docstring',
+        'add_newdoc',
+        'add_newdoc_ufunc',
+        # Builtins
+        'bool',
+        'complex',
+        'float',
+        'int',
+        'long',
+        'object',
+        'str',
+        'unicode',
+        # Should use numpy_financial instead
+        'fv',
+        'ipmt',
+        'irr',
+        'mirr',
+        'nper',
+        'npv',
+        'pmt',
+        'ppmt',
+        'pv',
+        'rate',
+    },
+}
+
 
 class FindAttributes(ast.NodeVisitor):
     """Find top-level attributes/functions/classes in the stubs.
@@ -66,7 +100,9 @@ def find_missing(module_name):
         # No stubs for this module yet.
         stubs_attributes = set()
 
-    missing = module_attributes - stubs_attributes
+    blacklist = BLACKLIST.get(module_name, set())
+
+    missing = module_attributes - stubs_attributes - blacklist
     print('\n'.join(sorted(missing)))
 
 


### PR DESCRIPTION
Now you can run something like

```
./runtests.py --find-missing numpy
```

to get a list of everything that still needs annotations added.