### PR TITLE
ENH: add __name__ attribue to ufuncs

### DIFF
--- a/numpy-stubs/__init__.pyi
+++ b/numpy-stubs/__init__.pyi
@@ -620,6 +620,8 @@ little_endian: int
 tracemalloc_domain: int
 
 class ufunc:
+    @property
+    def __name__(self) -> str: ...
     def __call__(
         self,
         *args: _ArrayLike,

--- a/tests/pass/ufuncs.py
+++ b/tests/pass/ufuncs.py
@@ -12,3 +12,4 @@ np.sin(1, signature='D')
 np.sin(1, extobj=[16, 1, lambda: None])
 np.sin(1) + np.sin(1)
 np.sin.types[0]
+np.sin.__name__


### PR DESCRIPTION
Follow up to https://github.com/numpy/numpy-stubs/pull/44.

SciPy actually uses `__name__`, so add it.