### PR TITLE
Add Python 3.8 to the CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
 matrix:
   include:
+    - python: 3.8
+      dist: xenial
     - python: 3.7
       dist: xenial
-      sudo: true
     - python: 3.6
+      dist: xenial
 
 notifications:
   email: false

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 black==18.9b0
-flake8==3.6.0
+flake8==3.7.9
 flake8-pyi==18.3.1
 pytest==4.0.0
 mypy==0.770


### PR DESCRIPTION
This also required bumping the flake8 version.

While experimenting with plugins in https://github.com/numpy/numpy-stubs/pull/56 I was getting CI failures on 3.7 but not 3.6, so it seemed prudent to expand our CI matrix.