### PR TITLE
MAINT: move __getattr__ to the top of __init__.pyi

### DIFF
--- a/numpy-stubs/__init__.pyi
+++ b/numpy-stubs/__init__.pyi
@@ -35,6 +35,9 @@ if sys.version_info[0] < 3:
 else:
     from typing import SupportsBytes
 
+# TODO: remove when the full numpy namespace is defined
+def __getattr__(name: str) -> Any: ...
+
 _Shape = Tuple[int, ...]
 
 # Anything that can be coerced to a shape tuple
@@ -775,9 +778,6 @@ tan: ufunc
 tanh: ufunc
 true_divide: ufunc
 trunc: ufunc
-
-# TODO(shoyer): remove when the full numpy namespace is defined
-def __getattr__(name: str) -> Any: ...
 
 # Warnings
 class ModuleDeprecationWarning(DeprecationWarning): ...


### PR DESCRIPTION
We have a

```
def __getattr__(name: str) -> Any: ...
```

since not everything is typed yet. It was originally at the bottom of
the `__init__.pyi` file, but has since ended up not at the end because
it's hard to remember to put your code above it. Since it makes sense
to have it somewhere more noticeable than the middle of the file, put
it at the top instead.