### PR TITLE
Added typing_extensions as a dependency for Python < 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,22 +6,25 @@ def find_stubs(package):
     stubs = []
     for root, dirs, files in os.walk(package):
         for file in files:
-            path = os.path.join(root, file).replace(package + os.sep, '', 1)
+            path = os.path.join(root, file).replace(package + os.sep, "", 1)
             stubs.append(path)
     return {package: stubs}
 
 
 setup(
-    name='numpy-stubs',
+    name="numpy-stubs",
     maintainer="NumPy Developers",
     maintainer_email="numpy-discussion@python.org",
     description="PEP 561 type stubs for numpy",
     url="http://www.numpy.org",
-    license='BSD',
+    license="BSD",
     version="0.0.1",
-    packages=['numpy-stubs'],
+    packages=["numpy-stubs"],
     # PEP 561 requires these
-    install_requires=['numpy>=1.14.0'],
-    package_data=find_stubs('numpy-stubs'),
+    install_requires=[
+        "numpy>=1.14.0",
+        'typing_extensions>=3.7.4; python_version<"3.8"',
+    ],
+    package_data=find_stubs("numpy-stubs"),
     zip_safe=False,
 )


### PR DESCRIPTION
* Added [``typing_extensions``](https://pypi.org/project/typing-extensions/) as a dependency for Python < 3.8.
* Ran black on setup.py.