### PR TITLE
MAINT: run black on all files in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 
 script:
 - flake8
-- black --check numpy-stubs
+- black --check .
 - py.test
 
 cache:

--- a/runtests.py
+++ b/runtests.py
@@ -10,12 +10,12 @@ STUBS_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 def main():
     subprocess.run(
-        [sys.executable, '-m', 'pip', 'install', STUBS_ROOT],
+        [sys.executable, "-m", "pip", "install", STUBS_ROOT],
         capture_output=True,
         check=True,
     )
     sys.exit(pytest.main([STUBS_ROOT] + sys.argv[1:]))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/find_ufuncs.py
+++ b/scripts/find_ufuncs.py
@@ -10,12 +10,12 @@ def main():
 
     ufunc_stubs = []
     for ufunc in set(ufuncs):
-        ufunc_stubs.append(f'{ufunc.__name__}: ufunc')
+        ufunc_stubs.append(f"{ufunc.__name__}: ufunc")
     ufunc_stubs.sort()
 
     for stub in ufunc_stubs:
         print(stub)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/fail/scalars.py
+++ b/tests/fail/scalars.py
@@ -28,8 +28,8 @@ np.complex64(1, 2)  # E: Too many arguments
 
 np.datetime64(0)  # E: non-matching overload
 
-dt_64 = np.datetime64(0, 'D')
-td_64 = np.timedelta64(1, 'h')
+dt_64 = np.datetime64(0, "D")
+td_64 = np.timedelta64(1, "h")
 
 dt_64 + dt_64  # E: Unsupported operand types
 

--- a/tests/fail/ufuncs.py
+++ b/tests/fail/ufuncs.py
@@ -1,5 +1,5 @@
 import numpy as np
 
-np.sin.nin + 'foo'  # E: Unsupported operand types
-np.sin(1, foo='bar')  # E: Unexpected keyword argument
-np.sin(1, extobj=['foo', 'foo', 'foo'])  # E: incompatible type
+np.sin.nin + "foo"  # E: Unsupported operand types
+np.sin(1, foo="bar")  # E: Unexpected keyword argument
+np.sin(1, extobj=["foo", "foo", "foo"])  # E: incompatible type

--- a/tests/fail/warnings_and_errors.py
+++ b/tests/fail/warnings_and_errors.py
@@ -2,4 +2,6 @@ import numpy as np
 
 np.AxisError(1.0)  # E: Argument 1 to "AxisError" has incompatible type
 np.AxisError(1, ndim=2.0)  # E: Argument "ndim" to "AxisError" has incompatible type
-np.AxisError(2, msg_prefix=404)  # E: Argument "msg_prefix" to "AxisError" has incompatible type
+np.AxisError(
+    2, msg_prefix=404  # E: Argument "msg_prefix" to "AxisError" has incompatible type
+)

--- a/tests/pass/scalars.py
+++ b/tests/pass/scalars.py
@@ -53,16 +53,16 @@ np.uint64().shape
 
 # Time structures
 np.datetime64()
-np.datetime64(0, 'D')
-np.datetime64('2019')
-np.datetime64('2019', 'D')
+np.datetime64(0, "D")
+np.datetime64("2019")
+np.datetime64("2019", "D")
 
 np.timedelta64()
 np.timedelta64(0)
-np.timedelta64(0, 'D')
+np.timedelta64(0, "D")
 
-dt_64 = np.datetime64(0, 'D')
-td_64 = np.timedelta64(1, 'h')
+dt_64 = np.datetime64(0, "D")
+td_64 = np.timedelta64(1, "h")
 
 dt_64 + td_64
 dt_64 - dt_64
@@ -70,6 +70,6 @@ dt_64 - td_64
 
 td_64 + td_64
 td_64 - td_64
-td_64 / 1.
+td_64 / 1.0
 td_64 / td_64
 td_64 % td_64

--- a/tests/pass/simple.py
+++ b/tests/pass/simple.py
@@ -6,9 +6,13 @@ from typing import Iterable  # noqa: F401
 
 # Basic checks
 array = np.array([1, 2])
+
+
 def ndarray_func(x):
     # type: (np.ndarray) -> np.ndarray
     return x
+
+
 ndarray_func(np.array([1, 2]))
 array == 1
 array.dtype == float
@@ -21,38 +25,40 @@ ndarray_func(np.ones([1, 2]))
 np.dtype(float)
 np.dtype(np.float64)
 np.dtype(None)
-np.dtype('float64')
+np.dtype("float64")
 np.dtype(np.dtype(float))
-np.dtype(('U', 10))
+np.dtype(("U", 10))
 np.dtype((np.int32, (2, 2)))
 # Define the arguments on the previous line to prevent bidirectional
 # type inference in mypy from broadening the types.
-two_tuples_dtype = [('R', 'u1'), ('G', 'u1'), ('B', 'u1')]
+two_tuples_dtype = [("R", "u1"), ("G", "u1"), ("B", "u1")]
 np.dtype(two_tuples_dtype)
 
-three_tuples_dtype = [('R', 'u1', 1)]
+three_tuples_dtype = [("R", "u1", 1)]
 np.dtype(three_tuples_dtype)
 
-mixed_tuples_dtype = [('R', 'u1'), ('G', np.unicode_, 1)]
+mixed_tuples_dtype = [("R", "u1"), ("G", np.unicode_, 1)]
 np.dtype(mixed_tuples_dtype)
 
-shape_tuple_dtype = [('R', 'u1', (2, 2))]
+shape_tuple_dtype = [("R", "u1", (2, 2))]
 np.dtype(shape_tuple_dtype)
 
-shape_like_dtype = [('R', 'u1', (2, 2)), ('G', np.unicode_, 1)]
+shape_like_dtype = [("R", "u1", (2, 2)), ("G", np.unicode_, 1)]
 np.dtype(shape_like_dtype)
 
-object_dtype = [('field1', object)]
+object_dtype = [("field1", object)]
 np.dtype(object_dtype)
 
-np.dtype({'col1': ('U10', 0), 'col2': ('float32', 10)})
-np.dtype((np.int32, {'real': (np.int16, 0), 'imag': (np.int16, 2)}))
+np.dtype({"col1": ("U10", 0), "col2": ("float32", 10)})
+np.dtype((np.int32, {"real": (np.int16, 0), "imag": (np.int16, 2)}))
 np.dtype((np.int32, (np.int8, 4)))
 
 # Iteration and indexing
 def iterable_func(x):
     # type: (Iterable) -> Iterable
     return x
+
+
 iterable_func(array)
 [element for element in array]
 iter(array)

--- a/tests/pass/ufuncs.py
+++ b/tests/pass/ufuncs.py
@@ -3,12 +3,8 @@ import numpy as np
 np.sin(1)
 np.sin([1, 2, 3])
 np.sin(1, out=np.empty(1))
-np.matmul(
-    np.ones((2, 2, 2)),
-    np.ones((2, 2, 2)),
-    axes=[(0, 1), (0, 1), (0, 1)],
-)
-np.sin(1, signature='D')
+np.matmul(np.ones((2, 2, 2)), np.ones((2, 2, 2)), axes=[(0, 1), (0, 1), (0, 1)])
+np.sin(1, signature="D")
 np.sin(1, extobj=[16, 1, lambda: None])
 np.sin(1) + np.sin(1)
 np.sin.types[0]

--- a/tests/pass/warnings_and_errors.py
+++ b/tests/pass/warnings_and_errors.py
@@ -3,5 +3,5 @@ import numpy as np
 np.AxisError(1)
 np.AxisError(1, ndim=2)
 np.AxisError(1, ndim=None)
-np.AxisError(1, ndim=2, msg_prefix='error')
+np.AxisError(1, ndim=2, msg_prefix="error")
 np.AxisError(1, ndim=2, msg_prefix=None)

--- a/tests/reveal/ndarray_conversion.py
+++ b/tests/reveal/ndarray_conversion.py
@@ -38,6 +38,7 @@ reveal_type(nd.copy("C"))  # E: numpy.ndarray
 class SubArray(np.ndarray):
     pass
 
+
 reveal_type(nd.view())  # E: numpy.ndarray
 reveal_type(nd.view(np.int64))  # E: numpy.ndarray
 # replace `Any` with `numpy.matrix` when `matrix` will be added to stubs
@@ -51,4 +52,3 @@ reveal_type(nd.getfield(float, 8))  # E: numpy.ndarray
 
 # setflags does not return a value
 # fill does not return a value
-

--- a/tests/reveal/scalars.py
+++ b/tests/reveal/scalars.py
@@ -8,23 +8,23 @@ reveal_type(x.imag)  # E: numpy.float32
 reveal_type(x.real.real)  # E: numpy.float32
 reveal_type(x.real.imag)  # E: numpy.float32
 
-reveal_type(x.itemsize)   # E: int
-reveal_type(x.shape)      # E: tuple[builtins.int]
-reveal_type(x.strides)    # E: tuple[builtins.int]
+reveal_type(x.itemsize)  # E: int
+reveal_type(x.shape)  # E: tuple[builtins.int]
+reveal_type(x.strides)  # E: tuple[builtins.int]
 
 # Time structures
-dt = np.datetime64(0, 'D')
-td = np.timedelta64(0, 'D')
+dt = np.datetime64(0, "D")
+td = np.timedelta64(0, "D")
 
 reveal_type(dt + td)  # E: numpy.datetime64
-reveal_type(dt + 1)   # E: numpy.datetime64
+reveal_type(dt + 1)  # E: numpy.datetime64
 reveal_type(dt - dt)  # E: numpy.timedelta64
-reveal_type(dt - 1)   # E: numpy.timedelta64
+reveal_type(dt - 1)  # E: numpy.timedelta64
 
 reveal_type(td + td)  # E: numpy.timedelta64
-reveal_type(td + 1)   # E: numpy.timedelta64
+reveal_type(td + 1)  # E: numpy.timedelta64
 reveal_type(td - td)  # E: numpy.timedelta64
-reveal_type(td - 1)   # E: numpy.timedelta64
-reveal_type(td / 1.)  # E: numpy.timedelta64
+reveal_type(td - 1)  # E: numpy.timedelta64
+reveal_type(td / 1.0)  # E: numpy.timedelta64
 reveal_type(td / td)  # E: float
 reveal_type(td % td)  # E: numpy.timedelta64

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -26,7 +26,7 @@ def get_test_cases(directory):
                         continue
                     if py_version_number == 3 and skip_py3:
                         continue
-                    py2_arg = ['--py2'] if py_version_number == 2 else []
+                    py2_arg = ["--py2"] if py_version_number == 2 else []
 
                     yield pytest.param(
                         fullpath,
@@ -40,10 +40,7 @@ def get_test_cases(directory):
 def test_success(path, py2_arg):
     stdout, stderr, exitcode = api.run([path] + py2_arg)
     assert exitcode == 0, stdout
-    assert re.match(
-        r'Success: no issues found in \d+ source files?',
-        stdout.strip(),
-    )
+    assert re.match(r"Success: no issues found in \d+ source files?", stdout.strip())
 
 
 @pytest.mark.parametrize("path,py2_arg", get_test_cases(FAIL_DIR))
@@ -58,7 +55,7 @@ def test_fail(path, py2_arg):
     errors = defaultdict(lambda: "")
     error_lines = stdout.rstrip("\n").split("\n")
     assert re.match(
-        r'Found \d+ errors? in \d+ files? \(checked \d+ source files?\)',
+        r"Found \d+ errors? in \d+ files? \(checked \d+ source files?\)",
         error_lines[-1].strip(),
     )
     for error_line in error_lines[:-1]:
@@ -80,7 +77,7 @@ def test_fail(path, py2_arg):
             assert lineno in errors, f'Extra error "{marker}"'
             assert marker in errors[lineno]
         else:
-            pytest.fail(f'Error {repr(errors[lineno])} not found')
+            pytest.fail(f"Error {repr(errors[lineno])} not found")
 
 
 @pytest.mark.parametrize("path,py2_arg", get_test_cases(REVEAL_DIR))


### PR DESCRIPTION
In https://github.com/numpy/numpy-stubs/pull/63 black was run on `setup.py`. Follow up by running black on all files in CI. Do an inital pass over the entire codebase so that the CI check will pass.

I'm usually opposed to things like this, but it seems like we're in an early enough stage that it should be ok.