### PR TITLE
TST: also run the code in "pass"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=["numpy-stubs"],
     # PEP 561 requires these
     install_requires=[
-        "numpy>=1.14.0",
+        "numpy>=1.16.0",
         'typing_extensions>=3.7.4; python_version<"3.8"',
     ],
     package_data=find_stubs("numpy-stubs"),

--- a/tests/pass/ndarray_conversion.py
+++ b/tests/pass/ndarray_conversion.py
@@ -1,9 +1,12 @@
+import tempfile
+
 import numpy as np
 
 nd = np.array([[1, 2], [3, 4]])
+scalar_array = np.array(1)
 
 # item
-nd.item()  # `nd` should be one-element in runtime
+scalar_array.item()
 nd.item(1)
 nd.item(0, 1)
 nd.item((0, 1))
@@ -11,7 +14,7 @@ nd.item((0, 1))
 # tolist is pretty simple
 
 # itemset
-nd.itemset(3)  # `nd` should be one-element in runtime
+scalar_array.itemset(3)
 nd.itemset(3, 0)
 nd.itemset((0, 0), 3)
 
@@ -25,14 +28,15 @@ nd.tobytes("C")
 nd.tobytes(None)
 
 # tofile
-nd.tofile("a.txt")
-nd.tofile(open("a.txt", mode="bw"))
+with tempfile.NamedTemporaryFile(suffix=".txt") as tmp:
+    nd.tofile(tmp.name)
+    nd.tofile(tmp.name, "")
+    nd.tofile(tmp.name, sep="")
 
-nd.tofile("a.txt", "")
-nd.tofile("a.txt", sep="")
+    nd.tofile(tmp.name, "", "%s")
+    nd.tofile(tmp.name, format="%s")
 
-nd.tofile("a.txt", "", "%s")
-nd.tofile("a.txt", format="%s")
+    nd.tofile(tmp)
 
 # dump is pretty simple
 # dumps is pretty simple
@@ -69,11 +73,13 @@ nd.view(np.int64, np.matrix)
 nd.view(type=np.matrix)
 
 # getfield
-nd.getfield("float")
-nd.getfield(float)
+complex_array = np.array([[1 + 1j, 0], [0, 1 - 1j]], dtype=np.complex128)
 
-nd.getfield("float", 8)
-nd.getfield(float, offset=8)
+complex_array.getfield("float")
+complex_array.getfield(float)
+
+complex_array.getfield("float", 8)
+complex_array.getfield(float, offset=8)
 
 # setflags
 nd.setflags()

--- a/tests/pass/ndarray_shape_manipulation.py
+++ b/tests/pass/ndarray_shape_manipulation.py
@@ -1,42 +1,47 @@
 import numpy as np
 
-nd = np.array([[1, 2], [3, 4]])
+nd1 = np.array([[1, 2], [3, 4]])
 
 # reshape
-nd.reshape()
-nd.reshape(4)
-nd.reshape(2, 2)
-nd.reshape((2, 2))
+nd1.reshape(4)
+nd1.reshape(2, 2)
+nd1.reshape((2, 2))
 
-nd.reshape((2, 2), order="C")
-nd.reshape(4, order="C")
+nd1.reshape((2, 2), order="C")
+nd1.reshape(4, order="C")
 
 # resize
-nd.resize()
-nd.resize(4)
-nd.resize(2, 2)
-nd.resize((2, 2))
+nd1.resize()
+nd1.resize(4)
+nd1.resize(2, 2)
+nd1.resize((2, 2))
 
-nd.resize((2, 2), refcheck=True)
-nd.resize(4, refcheck=True)
+nd1.resize((2, 2), refcheck=True)
+nd1.resize(4, refcheck=True)
+
+nd2 = np.array([[1, 2], [3, 4]])
 
 # transpose
-nd.transpose()
-nd.transpose(1, 0)
-nd.transpose((1, 0))
+nd2.transpose()
+nd2.transpose(1, 0)
+nd2.transpose((1, 0))
 
 # swapaxes
-nd.swapaxes(0, 1)
+nd2.swapaxes(0, 1)
 
 # flatten
-nd.flatten()
-nd.flatten("C")
+nd2.flatten()
+nd2.flatten("C")
 
 # ravel
-nd.ravel()
-nd.ravel("C")
+nd2.ravel()
+nd2.ravel("C")
 
 # squeeze
-nd.squeeze()
-nd.squeeze(0)
-nd.squeeze((0, 2))
+nd2.squeeze()
+
+nd3 = np.array([[1, 2]])
+nd3.squeeze(0)
+
+nd4 = np.array([[[1, 2]]])
+nd4.squeeze((0, 1))

--- a/tests/pass/scalars.py
+++ b/tests/pass/scalars.py
@@ -17,7 +17,6 @@ class A:
         return 4.0
 
 
-np.complex32(3)
 np.complex64(3j)
 np.complex64(C())
 

--- a/tests/pass/simple.py
+++ b/tests/pass/simple.py
@@ -114,7 +114,8 @@ array *= 1
 
 array / 1
 1 / array
-array /= 1
+float_array = np.array([1.0, 2.0])
+float_array /= 1
 
 array // 1
 1 // array

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -1,3 +1,5 @@
+import importlib.util
+import itertools
 import os
 import re
 from collections import defaultdict
@@ -86,3 +88,12 @@ def test_reveal(path):
         assert "Revealed type is" in error_line
         marker = lines[lineno - 1].split("# E:")[-1].strip()
         assert marker in error_line
+
+
+@pytest.mark.parametrize("path", get_test_cases(PASS_DIR))
+def test_code_runs(path):
+    path_without_extension, _ = os.path.splitext(path)
+    dirname, filename = path.split(os.sep)[-2:]
+    spec = importlib.util.spec_from_file_location(f"{dirname}.{filename}", path)
+    test_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(test_module)


### PR DESCRIPTION
It seems fair that the code in pass should also run; i.e. that
directory shouldn't contain mypy false positives. Add a test that runs
the modules in that directory and fix the resulting runtime errors.