### PR TITLE
MAINT: add more functions to the blacklist

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -16,11 +16,24 @@ BLACKLIST = {
     "numpy": {
         # Stdlib modules in the namespace by accident
         "absolute_import",
+        "division",
+        "print_function",
         "warnings",
-        # Accidentally public
+        # Accidentally public, deprecated, or shouldn't be used
+        "Tester",
         "add_docstring",
         "add_newdoc",
         "add_newdoc_ufunc",
+        "core",
+        "fastCopyAndTranspose",
+        "get_array_wrap",
+        "int_asbuffer",
+        "oldnumeric",
+        "recfromcsv",
+        "recfromtxt",
+        "safe_eval",
+        "set_numeric_ops",
+        "test",
         # Builtins
         "bool",
         "complex",
@@ -41,6 +54,9 @@ BLACKLIST = {
         "ppmt",
         "pv",
         "rate",
+        # More standard names should be preferred
+        "alltrue",  # all
+        "sometrue",  # any
     }
 }
 

--- a/runtests.py
+++ b/runtests.py
@@ -29,8 +29,6 @@ BLACKLIST = {
         "get_array_wrap",
         "int_asbuffer",
         "oldnumeric",
-        "recfromcsv",
-        "recfromtxt",
         "safe_eval",
         "set_numeric_ops",
         "test",


### PR DESCRIPTION
Found a few more functions that we shouldn't add types for.